### PR TITLE
Removed duplicate addition of .webp extension to filename

### DIFF
--- a/src/Extensions/ImageExtension.php
+++ b/src/Extensions/ImageExtension.php
@@ -127,7 +127,7 @@ class ImageExtension extends DataExtension
         // otherwise use the existing variant
         $store = Injector::inst()->get(AssetStore::class);
         $tuple = $manipulationResult = null;
-        if (!$store->exists($filename . '.webp', $hash, $variant)) {
+        if (!$store->exists($filename, $hash, $variant)) {
             // Circumvent generation of thumbnails if we only want to get existing ones
             if (!$this->owner->getAllowGeneration()) {
                 return null;


### PR DESCRIPTION
When checking if asset in store exists, .webp extension is again added to $filename, and we get filename with extension *.webp.webp, which does not exist and webp variant creation is triggered on every request.

I have removed duplicate addition of webp extension.